### PR TITLE
Restrict number of log entries on win agent

### DIFF
--- a/src/AsimovDeploy.WinAgent.Tests/VersionLogSpecs.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/VersionLogSpecs.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using AsimovDeploy.WinAgent.Framework.Common;
 using AsimovDeploy.WinAgent.Framework.Models;
 using NUnit.Framework;
@@ -75,6 +76,30 @@ namespace AsimovDeploy.WinAgent.Tests
             log[0].VersionTimestamp.ShouldBe(timestamp);
             log[0].VersionId.ShouldBe("theId2");
             log[0].VersionNumber.ShouldBe("v1.2.3.5");
+        }
+
+        [Test]
+        public void restricts_number_of_versions_that_are_saved()
+        {
+            var timestamp = DateTime.Now;
+            var SavedEntries = VersionUtil.MAX_LOG_ENTRIES + 10;
+            for (int i = 1; i <= SavedEntries; i++)
+            {
+                VersionUtil.UpdateVersionLog(".", new DeployedVersion()
+                {
+                    VersionBranch = "master",
+                    VersionCommit = "123",
+                    VersionTimestamp = timestamp,
+                    VersionId = i.ToString(),
+                    VersionNumber = "v1.2.3.4",
+                    LogFileName = "logfile.txt"
+                });
+            }
+            var log = VersionUtil.ReadVersionLog(".");
+            log.Count.ShouldBe(VersionUtil.MAX_LOG_ENTRIES);
+            var versions = log.Select(x=>x.VersionId);
+            versions.ShouldContain(SavedEntries.ToString());
+            versions.ShouldContain("11");
         }
         
     }

--- a/src/AsimovDeploy.WinAgent/Framework/Common/VersionUtil.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Common/VersionUtil.cs
@@ -17,6 +17,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -27,6 +28,7 @@ namespace AsimovDeploy.WinAgent.Framework.Common
 {
     public static class VersionUtil
     {
+        public const int MAX_LOG_ENTRIES = 250;
         public static string VERSION_LOG_FILENAME = "version-log.json";
 
         public static string GetAgentVersion()
@@ -52,11 +54,14 @@ namespace AsimovDeploy.WinAgent.Framework.Common
 
         private static void UpdateLog(string inDirectory, List<DeployedVersion> log)
         {
+            //Node frontend chokes when the log gets to long so we only save the last 250 entries
+            var deployedVersionsToSave = log.Take(MAX_LOG_ENTRIES).ToList();
+
             using (var writer = new StreamWriter(Path.Combine(inDirectory, VERSION_LOG_FILENAME), false, Encoding.UTF8))
             {
                 var serializer = new JsonSerializer();
                 serializer.Formatting = Formatting.Indented;
-                serializer.Serialize(writer, log);
+                serializer.Serialize(writer, deployedVersionsToSave);
             }
         }
 


### PR DESCRIPTION
The nodefront chokes when the commit log gets too long. This commit restrict the commit log on the agent to 250 entries to fix that.