### PR TITLE
Clean physical path before windows service install

### DIFF
--- a/src/AsimovDeploy.WinAgent/AsimovDeploy.WinAgent.csproj
+++ b/src/AsimovDeploy.WinAgent/AsimovDeploy.WinAgent.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Framework\Models\Units\ICanUninistall.cs" />
     <Compile Include="Framework\Models\UnitActions\UninstallUnitAction.cs" />
     <Compile Include="Framework\Deployment\Steps\InstallWebSite.cs" />
+    <Compile Include="Framework\Models\Units\IServiceInfo.cs" />
     <Compile Include="Framework\Tasks\PowershellUninstallTask.cs" />
     <Compile Include="Framework\Models\Units\InstallableConfig.cs" />
     <Compile Include="Framework\Tasks\CommandTask.cs" />

--- a/src/AsimovDeploy.WinAgent/Framework/Common/DirectoryUtil.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Common/DirectoryUtil.cs
@@ -49,5 +49,9 @@ namespace AsimovDeploy.WinAgent.Framework.Common
             }
         }
 
+        public static bool Exists(string path)
+        {
+            return Directory.Exists(path);
+        }
     }
 }

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/IServiceInfo.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/IServiceInfo.cs
@@ -1,0 +1,8 @@
+namespace AsimovDeploy.WinAgent.Framework.Models.Units
+{
+    public interface IInstallableService
+    {
+        string ServiceName { get; set; }
+        InstallableConfig Installable { get; set; }
+    }
+}

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/WindowsServiceDeployUnit.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/WindowsServiceDeployUnit.cs
@@ -24,7 +24,7 @@ using AsimovDeploy.WinAgent.Framework.Tasks;
 
 namespace AsimovDeploy.WinAgent.Framework.Models.Units
 {
-    public class WindowsServiceDeployUnit : DeployUnit, ICanBeStopStarted, ICanUninistall
+    public class WindowsServiceDeployUnit : DeployUnit, ICanBeStopStarted, ICanUninistall, IInstallableService
     {
         private string _serviceName;
         public string ServiceName
@@ -50,7 +50,7 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
         {
             var task = new DeployTask(this, version, parameterValues, user, correlationId);
             if (CanInstall())
-                task.AddDeployStep(new InstallWindowsService(Installable));
+                task.AddDeployStep(new InstallWindowsService(this));
             else
                 task.AddDeployStep<UpdateWindowsService>();
 


### PR DESCRIPTION
This pull request does two things:
1) It cleans the target path before installing a windows service so that old assemblies does not interfere with the installation
2) It allows us to use $ServiceName in the install script