### PR TITLE
Allow using ServiceName in windows service uninstall

### DIFF
--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/WindowsServiceDeployUnit.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/WindowsServiceDeployUnit.cs
@@ -104,6 +104,6 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
 
         public AsimovTask GetStopTask() => new StartStopWindowsServiceTask(this, stop: true);
         public AsimovTask GetStartTask() => new StartStopWindowsServiceTask(this, stop: false);
-        public AsimovTask GetUninstallTask() => new PowershellUninstallTask(Installable, this, new Dictionary<string, object>());
+        public AsimovTask GetUninstallTask() => new PowershellUninstallTask(Installable, this, new Dictionary<string, object>() { { "ServiceName", ServiceName } });
     }
 }


### PR DESCRIPTION
This needs refactoring so that install and uninstall collects parameters in the same way, but for now this fixes a problem we had