### PR TITLE
Fix retrieving of windows service installation path

### DIFF
--- a/src/AsimovDeploy.WinAgent.Tests/AsimovDeploy.WinAgent.Tests.csproj
+++ b/src/AsimovDeploy.WinAgent.Tests/AsimovDeploy.WinAgent.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tasks\ChangeLoadBalancerStateTaskSpecs.cs" />
     <Compile Include="Utils\FriendlyAgeSpecs.cs" />
+    <Compile Include="Utils\WindowsServiceUtilTests.cs" />
     <Compile Include="VersionLogSpecs.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AsimovDeploy.WinAgent.Tests/Utils/WindowsServiceUtilTests.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/Utils/WindowsServiceUtilTests.cs
@@ -1,0 +1,24 @@
+﻿using AsimovDeploy.WinAgent.Framework.Common;
+using NUnit.Framework;
+using Shouldly;
+
+namespace AsimovDeploy.WinAgent.Tests.Utils
+{
+    [TestFixture]
+    public class WindowsServiceUtilTests
+    {
+        [Test]
+        public void should_return_service_executable_for_path_starting_with_double_quote()
+        {
+            var serviceExe = WindowsServiceUtil.GetServiceExecutable(@"""C:\temp\service.exe"" -arg value");
+            serviceExe.ShouldBe(@"C:\temp\service.exe");
+        }
+
+        [Test]
+        public void should_return_service_executable_for_path_not_starting_with_double_quote()
+        {
+            var serviceExe = WindowsServiceUtil.GetServiceExecutable(@"C:\temp\service.exe -arg value");
+            serviceExe.ShouldBe(@"C:\temp\service.exe");
+        }
+    }
+}

--- a/src/AsimovDeploy.WinAgent/Framework/Common/WindowsServiceUtil.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Common/WindowsServiceUtil.cs
@@ -31,13 +31,23 @@ namespace AsimovDeploy.WinAgent.Framework.Common
             foreach (ManagementObject managementObject in managementObjectCollection)
             {
                 var path = managementObject.GetPropertyValue("PathName").ToString();
-                var serviceExe = Regex.Match(path, "([^\"])+").Groups[0].Value;
 
+                var serviceExe = GetServiceExecutable(path);
                 var fileInfo = new FileInfo(serviceExe);
                 return fileInfo.Directory.FullName;
             }
 
             return null;
+        }
+
+        public static string GetServiceExecutable(string windowsServicePath)
+        {
+            if (windowsServicePath.StartsWith("\""))
+            {
+                return Regex.Match(windowsServicePath, "([^\"])+").Groups[0].Value;
+            }
+
+            return Regex.Match(windowsServicePath, "([^\\s])+").Groups[0].Value;
         }
     }
 }


### PR DESCRIPTION
When retrieving windows service installation path we should handle an executable path not starting with double quotes