### PR TITLE
Fix tag support

### DIFF
--- a/src/AsimovDeploy.WinAgent/Framework/Models/AsimovConfig.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/AsimovConfig.cs
@@ -109,9 +109,9 @@ namespace AsimovDeploy.WinAgent.Framework.Models
             }
         }
 
-        public DeployUnits GetUnitsByStatus(string status)
+        public DeployUnits GetUnitsByStatus(string status, bool refreshUnitStatus)
         {
-            return new DeployUnits(Units.Where(x => x.GetUnitInfo().GetUnitStatus() == status));
+            return new DeployUnits(Units.Where(x => x.GetUnitInfo(refreshUnitStatus).GetUnitStatus() == status));
         }
 
         public string[] GetAgentGroups()

--- a/src/AsimovDeploy.WinAgent/Framework/Models/IAsimovConfig.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/IAsimovConfig.cs
@@ -46,7 +46,7 @@ namespace AsimovDeploy.WinAgent.Framework.Models
         DeployUnits GetUnitsByType(string unitType);
         DeployUnits GetUnitsByTag(string tag);
         DeployUnits GetUnitsByUnitName(string arg);
-        DeployUnits GetUnitsByStatus(string status);
+        DeployUnits GetUnitsByStatus(string status, bool refreshUnitStatus);
 
         string[] GetAgentGroups();
         string[] GetUnitGroups();

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/DeployUnit.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/DeployUnit.cs
@@ -51,7 +51,7 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
 
         public abstract AsimovTask GetDeployTask(AsimovVersion version, ParameterValues parameterValues, AsimovUser user, string correlationId);
 
-        public virtual DeployUnitInfo GetUnitInfo()
+        public virtual DeployUnitInfo GetUnitInfo(bool refreshUnitStatus)
         {
             var deployUnitInfo = new DeployUnitInfo
             {
@@ -60,6 +60,11 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
                 HasDeployParameters = HasDeployParameters,
 
             };
+
+            if (!refreshUnitStatus)
+            {
+                Version = new DeployedVersion() { VersionNumber = "0.0.0.0" };
+            }
 
             if (Version == null)
             {
@@ -83,7 +88,17 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
             deployUnitInfo.Version = Version;
             deployUnitInfo.DeployStatus = DeployStatus;
 
+            if (refreshUnitStatus)
+            {
+                UpdateUnitStatus();
+            }
+
             return deployUnitInfo;
+        }
+
+        protected virtual void UpdateUnitStatus()
+        {
+
         }
 
         public IList<DeployedVersion> GetDeployedVersions() => VersionUtil.ReadVersionLog(DataDirectory);
@@ -124,7 +139,7 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
 
             VersionUtil.UpdateVersionLog(DataDirectory, Version);
 
-            var unitInfo = GetUnitInfo();
+            var unitInfo = GetUnitInfo(true);
             NotificationPublisher.PublishNotifications(new DeployCompletedEvent(Name, Version, unitInfo.Status));
         }
 

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/PowershellDeployUnit.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/PowershellDeployUnit.cs
@@ -35,9 +35,9 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
             return task;
         }
 
-        public override DeployUnitInfo GetUnitInfo()
+        public override DeployUnitInfo GetUnitInfo(bool refreshUnitStatus)
         {
-            var deployUnitInfo = base.GetUnitInfo();
+            var deployUnitInfo = base.GetUnitInfo(refreshUnitStatus);
 
             deployUnitInfo.Status = UnitStatus.NA;
             deployUnitInfo.Url = Url != null ? Url.Replace("localhost", HostNameUtil.GetFullHostName()) : null;

--- a/src/AsimovDeploy.WinAgent/Framework/Tasks/PowershellUninstallTask.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Tasks/PowershellUninstallTask.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using AsimovDeploy.WinAgent.Framework.Common;
 using AsimovDeploy.WinAgent.Framework.Events;
-using AsimovDeploy.WinAgent.Framework.Models;
 using AsimovDeploy.WinAgent.Framework.Models.Units;
 
 namespace AsimovDeploy.WinAgent.Framework.Tasks
@@ -14,7 +13,8 @@ namespace AsimovDeploy.WinAgent.Framework.Tasks
         private readonly DeployUnit _unit;
         private readonly Dictionary<string, object> _unitParameters;
         private readonly NodeFront _nodefront = new NodeFront();
-        public PowershellUninstallTask(InstallableConfig config, DeployUnit unit, Dictionary<string,object> unitParameters)
+
+        public PowershellUninstallTask(InstallableConfig config, DeployUnit unit, Dictionary<string, object> unitParameters)
         {
             _installableConfig = config;
             _unit = unit;
@@ -26,6 +26,7 @@ namespace AsimovDeploy.WinAgent.Framework.Tasks
         protected override void Execute()
         {
             Log.Info($"Uninstalling {_unit.Name}...");
+
             if (string.IsNullOrEmpty(_installableConfig.TargetPath))
                 _installableConfig.TargetPath = Path.Combine(@"\Services", _unit.Name);
             if (!string.IsNullOrEmpty(_installableConfig.Uninstall))
@@ -39,7 +40,8 @@ namespace AsimovDeploy.WinAgent.Framework.Tasks
                 Log.Warn($"Uninstall of {_unit.Name} not supported. Please check InstallableConfig.");
                 return;
             }
-            _nodefront.Notify(new UnitStatusChangedEvent(_unit.Name, _unit.GetUnitInfo().Status));
+
+            _nodefront.Notify(new UnitStatusChangedEvent(_unit.Name, _unit.GetUnitInfo(true).Status));
             Log.Info($"Uninstall of {_unit.Name} done!");
         }
 
@@ -70,9 +72,9 @@ namespace AsimovDeploy.WinAgent.Framework.Tasks
         {
             ProcessUtil.ExecutePowershellScript(
                 GetTargetPath(),
-                _installableConfig.Uninstall, 
-                _unitParameters, Log, 
-                new [] {_installableConfig.ScriptsDir});
+                _installableConfig.Uninstall,
+                _unitParameters, Log,
+                new[] { _installableConfig.ScriptsDir });
 
         }
 

--- a/src/AsimovDeploy.WinAgent/Framework/Tasks/StartStopWebApplicationTask.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Tasks/StartStopWebApplicationTask.cs
@@ -37,7 +37,7 @@ namespace AsimovDeploy.WinAgent.Framework.Tasks
 			if (_stop) server.StopAppPool();
 			else server.StartAppPool();
 
-			var unitInfo = _unit.GetUnitInfo();
+			var unitInfo = _unit.GetUnitInfo(true);
 
 			if (unitInfo.Status != endStatus)
 			{

--- a/src/AsimovDeploy.WinAgent/Framework/Tasks/StartStopWindowsServiceTask.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Tasks/StartStopWindowsServiceTask.cs
@@ -43,7 +43,7 @@ namespace AsimovDeploy.WinAgent.Framework.Tasks
 
 			}
 
-			var unitInfo = _unit.GetUnitInfo();
+			var unitInfo = _unit.GetUnitInfo(true);
 
 			if (unitInfo.Status != endStatus)
 			{

--- a/src/AsimovDeploy.WinAgent/Service/AsimovDeployService.cs
+++ b/src/AsimovDeploy.WinAgent/Service/AsimovDeployService.cs
@@ -35,7 +35,7 @@ namespace AsimovDeploy.WinAgent.Service
                 ComponentRegistration.RegisterComponents();
                 ComponentRegistration.ReadAndRegisterConfiguration();
                 AddNodeFrontAppender();
-                ComponentRegistration.StartStartableComponenters();
+                ComponentRegistration.StartStartableComponents();
 
                 var config = ObjectFactory.GetInstance<IAsimovConfig>();
                 Log.InfoFormat("WinAgent Started, Version={0}, ConfigVersion={1}", VersionUtil.GetAgentVersion(), config.ConfigVersion);

--- a/src/AsimovDeploy.WinAgent/Service/AsimovDeployService.cs
+++ b/src/AsimovDeploy.WinAgent/Service/AsimovDeployService.cs
@@ -16,7 +16,6 @@
 
 using System;
 using AsimovDeploy.WinAgent.Framework.Common;
-using AsimovDeploy.WinAgent.Framework.Configuration;
 using AsimovDeploy.WinAgent.Framework.Models;
 using StructureMap;
 using log4net;
@@ -35,10 +34,11 @@ namespace AsimovDeploy.WinAgent.Service
                 ComponentRegistration.RegisterComponents();
                 ComponentRegistration.ReadAndRegisterConfiguration();
                 AddNodeFrontAppender();
+                Log.Info("WinAgent starting...");
                 ComponentRegistration.StartStartableComponents();
 
                 var config = ObjectFactory.GetInstance<IAsimovConfig>();
-                Log.InfoFormat("WinAgent Started, Version={0}, ConfigVersion={1}", VersionUtil.GetAgentVersion(), config.ConfigVersion);
+                Log.Info($"WinAgent started, Version={VersionUtil.GetAgentVersion()}, ConfigVersion={config.ConfigVersion}");
             }
             catch (Exception e)
             {
@@ -57,8 +57,9 @@ namespace AsimovDeploy.WinAgent.Service
 
         public void Stop()
         {
-            Log.Info("WinAgent Stopping");
+            Log.Info("WinAgent stopping...");
             ComponentRegistration.StopAll();
+            Log.Info("WinAgent stopped");
         }
     }
 }

--- a/src/AsimovDeploy.WinAgent/Service/ComponentRegistration.cs
+++ b/src/AsimovDeploy.WinAgent/Service/ComponentRegistration.cs
@@ -63,7 +63,7 @@ namespace AsimovDeploy.WinAgent.Service
             ObjectFactory.Configure(x => x.For<IAsimovConfig>().Use(config));
         }
 
-        public static void StartStartableComponenters()
+        public static void StartStartableComponents()
         {
             Log.Debug("Starting startable components...");
 

--- a/src/AsimovDeploy.WinAgent/Web/Contracts/GetDeployUnitsRequestDto.cs
+++ b/src/AsimovDeploy.WinAgent/Web/Contracts/GetDeployUnitsRequestDto.cs
@@ -24,5 +24,6 @@ namespace AsimovDeploy.WinAgent.Web.Contracts
         public string[] Tags { get; set; }
         public string[] Units { get; set; }
         public string[] UnitStatus { get; set; }
+        public bool SkipStatusRefresh { get; set; }
     }
 }


### PR DESCRIPTION
Make it possible to skip refresh of website and windows service statuses when retrieving deploy units. This should make the response times a lot faster.