### PR TITLE
Do not crash asimov deploy process when there are no environments

### DIFF
--- a/src/AsimovDeploy.WinAgent/Framework/Configuration/AsimovConfigConverter.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Configuration/AsimovConfigConverter.cs
@@ -51,7 +51,10 @@ namespace AsimovDeploy.WinAgent.Framework.Configuration
             if (self != null)
                 serializer.Populate(self.CreateReader(), config);
             else
+            {
                 Log.ErrorFormat("Could not find agent specific config / environment for: {0}", _machineName);
+                return config;
+            }
 
             var environments = config.Environment.Split(',');
 


### PR DESCRIPTION
Previously, asimov deploy crashed with NullReferenceException when started with
a config that contained no matching environments.