### PR TITLE
Increase google storage fetched objects

### DIFF
--- a/src/AsimovDeploy.WinAgent/Framework/Models/PackageSources/GoogleStoragePackageSource.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/PackageSources/GoogleStoragePackageSource.cs
@@ -10,7 +10,8 @@ namespace AsimovDeploy.WinAgent.Framework.Models.PackageSources
 {
     public class GoogleStoragePackageSource : PackageSource
     {
-        private const int MaxPageSize = 100;
+        private const int MaxPageSize = 10000;
+        private const int MaxReturnedResults = 100;
         private StorageClient _storageClient;
         private StorageClient StorageClient
         {
@@ -36,11 +37,13 @@ namespace AsimovDeploy.WinAgent.Framework.Models.PackageSources
         {
             var prefix = packageInfo.SourceRelativePath != null ? $"{Prefix}/{packageInfo.SourceRelativePath}" : Prefix;
             var objects = StorageClient.ListObjects(Bucket, prefix);
-            return objects
-                .ReadPage(MaxPageSize)
+            var readPage = objects
+                .ReadPage(MaxPageSize);
+            return readPage
                 .Select(ParseVersion)
                 .Where(x => x != null)
                 .OrderByDescending(x=>x.Timestamp)
+                .Take(MaxReturnedResults)
                 .ToList();
         }
 

--- a/src/AsimovDeploy.WinAgent/Framework/Models/PackageSources/GoogleStoragePackageSource.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/PackageSources/GoogleStoragePackageSource.cs
@@ -10,7 +10,7 @@ namespace AsimovDeploy.WinAgent.Framework.Models.PackageSources
 {
     public class GoogleStoragePackageSource : PackageSource
     {
-        private const int MaxPageSize = 10000;
+        private const int GoogleStoragePageSize = 10000;
         private const int MaxReturnedResults = 100;
         private StorageClient _storageClient;
         private StorageClient StorageClient
@@ -38,7 +38,7 @@ namespace AsimovDeploy.WinAgent.Framework.Models.PackageSources
             var prefix = packageInfo.SourceRelativePath != null ? $"{Prefix}/{packageInfo.SourceRelativePath}" : Prefix;
             var objects = StorageClient.ListObjects(Bucket, prefix);
             var readPage = objects
-                .ReadPage(MaxPageSize);
+                .ReadPage(GoogleStoragePageSize);
             return readPage
                 .Select(ParseVersion)
                 .Where(x => x != null)


### PR DESCRIPTION
Increase number of fetched objects from google storage in google storage package source to make it less likely that old packages hides new ones in the version list