### PR TITLE
Added KillDeployUnitAction to windows services

### DIFF
--- a/src/AsimovDeploy.WinAgent/Framework/Common/ProcessUtil.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Common/ProcessUtil.cs
@@ -26,7 +26,7 @@ namespace AsimovDeploy.WinAgent.Framework.Common
 {
     public class ProcessUtil
     {
-        public static void ExecutePowershellScript(string workingDirectory, string command, IEnumerable<KeyValuePair<string,object>> parameters, ILog log, IEnumerable<string> addToPath = null)
+        public static void ExecutePowershellScript(string workingDirectory, string command, IEnumerable<KeyValuePair<string, object>> parameters, ILog log, IEnumerable<string> addToPath = null)
         {
             using (var p = new Process())
             {
@@ -52,11 +52,11 @@ namespace AsimovDeploy.WinAgent.Framework.Common
 
                 if (addToPath != null)
                 {
-                    foreach (var path in addToPath.Where(pa=>!string.IsNullOrEmpty(pa)))
+                    foreach (var path in addToPath.Where(pa => !string.IsNullOrEmpty(pa)))
                     {
                         log.Info($"Add {path} to $end:Path");
                         p.StandardInput.WriteLine($"$env:Path += \";{path}\"");
-                    }   
+                    }
                 }
                 p.StandardInput.WriteLine(command);
                 p.StandardInput.Close();

--- a/src/AsimovDeploy.WinAgent/Framework/Common/WebNotificationPublisher.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Common/WebNotificationPublisher.cs
@@ -36,8 +36,7 @@ namespace AsimovDeploy.WinAgent.Framework.Common
                 {
                     using (var writer = new StreamWriter(requestStream))
                     {
-                        var serializer = new JsonSerializer();
-                        serializer.NullValueHandling = NullValueHandling.Ignore;
+                        var serializer = new JsonSerializer { NullValueHandling = NullValueHandling.Ignore };
                         serializer.Serialize(writer, evt);
                     }
                 }

--- a/src/AsimovDeploy.WinAgent/Framework/Configuration/AsimovConfigConverter.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Configuration/AsimovConfigConverter.cs
@@ -66,28 +66,30 @@ namespace AsimovDeploy.WinAgent.Framework.Configuration
                     continue;
 
                 Log.DebugFormat("Loading config file {0}", envConfigFile);
-				PopulateFromFile(envConfigFile, serializer, config);
+                PopulateFromFile(envConfigFile, serializer, config);
 
-				var env = new DeployEnvironment();
-				PopulateFromFile(envConfigFile, serializer, env);
-				config.Environments.Add(env);
-			}
+                var env = new DeployEnvironment();
+                PopulateFromFile(envConfigFile, serializer, env);
+                config.Environments.Add(env);
+
+                config.Units?.ForEach(t => t.SetupDeployActions());
+            }
 
             return config;
         }
 
-	    private void PopulateFromFile(string filename, JsonSerializer serializer, object target)
-	    {
-			using (var envReader = new StreamReader(filename))
-			{
-				using (var envJsonReader = new JsonTextReader(envReader))
-				{
-					serializer.Populate(envJsonReader, target);
-				}
-			}
-		}
+        private void PopulateFromFile(string filename, JsonSerializer serializer, object target)
+        {
+            using (var envReader = new StreamReader(filename))
+            {
+                using (var envJsonReader = new JsonTextReader(envReader))
+                {
+                    serializer.Populate(envJsonReader, target);
+                }
+            }
+        }
 
-		private JToken GetSelf(JObject json)
+        private JToken GetSelf(JObject json)
         {
             var agents = json["Agents"];
             if (agents == null)

--- a/src/AsimovDeploy.WinAgent/Framework/Deployment/Steps/InstallWebSite.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Deployment/Steps/InstallWebSite.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using AsimovDeploy.WinAgent.Framework.Common;
-using AsimovDeploy.WinAgent.Framework.Models;
 using AsimovDeploy.WinAgent.Framework.Models.Units;
 
 namespace AsimovDeploy.WinAgent.Framework.Deployment.Steps
@@ -11,12 +9,7 @@ namespace AsimovDeploy.WinAgent.Framework.Deployment.Steps
     {
         private readonly IWebSiteDeployUnit _unit;
 
-        public InstallWebSite(IWebSiteDeployUnit unit)
-        {
-            if(unit == null)
-                throw new ArgumentNullException(nameof(unit));
-            _unit = unit;
-        }
+        public InstallWebSite(IWebSiteDeployUnit unit) => _unit = unit ?? throw new ArgumentNullException(nameof(unit));
 
         public void Execute(DeployContext context)
         {
@@ -40,7 +33,7 @@ namespace AsimovDeploy.WinAgent.Framework.Deployment.Steps
                 _unit.Installable.TargetPath,
                 _unit.Installable.Install,
                 parameters,
-                context.Log, 
+                context.Log,
                 new[] { _unit.Installable.ScriptsDir });
         }
 

--- a/src/AsimovDeploy.WinAgent/Framework/Models/AsimovConfig.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/AsimovConfig.cs
@@ -56,12 +56,12 @@ namespace AsimovDeploy.WinAgent.Framework.Models
         public string LoadBalancerServerId
         {
             get { return _loadBalancerServerId ?? System.Environment.MachineName.ToLowerInvariant(); }
-            set { _loadBalancerServerId = value; }
+            set => _loadBalancerServerId = value;
         }
         public int LoadBalancerTimeout
         {
             get { return _loadBalancerTimeout > 0 ? _loadBalancerTimeout : 30; }
-            set { _loadBalancerTimeout = value; }
+            set => _loadBalancerTimeout = value;
         }
 
         public string NodeFrontUrl { get; set; }
@@ -125,35 +125,29 @@ namespace AsimovDeploy.WinAgent.Framework.Models
                 .OrderBy(x => x).ToArray();
         }
 
-        public string[] GetUnitGroups()
-        {
-            return Units
-                .Where(x => x.Group != null)
-                .Select(x => x.Group)
-                .Distinct()
-                .OrderBy(x => x)
-                .ToArray();
-        }
+        public string[] GetUnitGroups() =>
+            Units
+            .Where(x => x.Group != null)
+            .Select(x => x.Group)
+            .Distinct()
+            .OrderBy(x => x)
+            .ToArray();
 
-        public string[] GetUnitTypes()
-        {
-            return Units
-                .Where(x => x.UnitType != null)
-                .Select(x => x.UnitType)
-                .Distinct()
-                .OrderBy(x => x)
-                .ToArray();
-        }
+        public string[] GetUnitTypes() =>
+            Units
+            .Where(x => x.UnitType != null)
+            .Select(x => x.UnitType)
+            .Distinct()
+            .OrderBy(x => x)
+            .ToArray();
 
-        public string[] GetUnitTags()
-        {
-            return Units
-                .Where(x => x.Tags != null)
-                .SelectMany(x => x.Tags)
-                .Distinct()
-                .OrderBy(x => x)
-                .ToArray();
-        }
+        public string[] GetUnitTags() =>
+            Units
+            .Where(x => x.Tags != null)
+            .SelectMany(x => x.Tags)
+            .Distinct()
+            .OrderBy(x => x)
+            .ToArray();
 
         public string[] GetUnitStatuses()
         {

--- a/src/AsimovDeploy.WinAgent/Framework/Models/UnitActions/KillDeployUnitAction.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/UnitActions/KillDeployUnitAction.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using AsimovDeploy.WinAgent.Framework.Common;
+using AsimovDeploy.WinAgent.Framework.Models.Units;
+using log4net;
+
+namespace AsimovDeploy.WinAgent.Framework.Models.UnitActions
+{
+    public class KillDeployUnitAction : UnitAction
+    {
+        private static ILog _log = LogManager.GetLogger(typeof(StopDeployUnitAction));
+
+        public KillDeployUnitAction() => Name = "Kill";
+
+        public override AsimovTask GetTask(DeployUnit unit, AsimovUser user, string correlationId)
+        {
+            if (!(unit is ICanBeKilled))
+                throw new ArgumentException("Action is only supported for deploy units that implement ICanBeKilled");
+
+            return ((ICanBeKilled)unit).GetKillTask();
+        }
+    }
+}

--- a/src/AsimovDeploy.WinAgent/Framework/Models/UnitActions/StartDeployUnitAction.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/UnitActions/StartDeployUnitAction.cs
@@ -7,14 +7,9 @@ namespace AsimovDeploy.WinAgent.Framework.Models.UnitActions
 {
 	public class StartDeployUnitAction : UnitAction
 	{
-        private static ILog _log = LogManager.GetLogger(typeof(StartDeployUnitAction));
+		public StartDeployUnitAction() => Name = "Start";
 
-		public StartDeployUnitAction()
-		{
-			Name = "Start";
-		}
-
-        public override AsimovTask GetTask(DeployUnit unit, AsimovUser user, string correlationId)
+	    public override AsimovTask GetTask(DeployUnit unit, AsimovUser user, string correlationId)
 		{
 			if (!(unit is ICanBeStopStarted))
 				throw new ArgumentException("Action is only supported for deploy units that implement ICanBeStopStarted");

--- a/src/AsimovDeploy.WinAgent/Framework/Models/UnitActions/StopDeployUnitAction.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/UnitActions/StopDeployUnitAction.cs
@@ -21,21 +21,18 @@ using log4net;
 
 namespace AsimovDeploy.WinAgent.Framework.Models.UnitActions
 {
-	public class StopDeployUnitAction : UnitAction
-	{
-		private static ILog _log = LogManager.GetLogger(typeof (StopDeployUnitAction));
+    public class StopDeployUnitAction : UnitAction
+    {
+        private static ILog _log = LogManager.GetLogger(typeof(StopDeployUnitAction));
 
-		public StopDeployUnitAction()
-		{
-			Name = "Stop";
-		}
+        public StopDeployUnitAction() => Name = "Stop";
 
         public override AsimovTask GetTask(DeployUnit unit, AsimovUser user, string correlationId)
-		{
-			if (!(unit is ICanBeStopStarted))
-				throw new ArgumentException("Action is only supported for deploy units that implement ICanBeStopStarted");
+        {
+            if (!(unit is ICanBeStopStarted))
+                throw new ArgumentException("Action is only supported for deploy units that implement ICanBeStopStarted");
 
-			return ((ICanBeStopStarted)unit).GetStopTask();
-		}
-	}
+            return ((ICanBeStopStarted)unit).GetStopTask();
+        }
+    }
 }

--- a/src/AsimovDeploy.WinAgent/Framework/Models/UnitActions/UninstallUnitAction.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/UnitActions/UninstallUnitAction.cs
@@ -22,10 +22,7 @@ namespace AsimovDeploy.WinAgent.Framework.Models.UnitActions
 {
     public class UnInstallUnitAction : UnitAction
     {
-        public UnInstallUnitAction()
-        {
-            Name = "Uninstall";
-        }
+        public UnInstallUnitAction() => Name = "Uninstall";
 
         public override AsimovTask GetTask(DeployUnit unit, AsimovUser user, string correlationId)
         {

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/DeployUnit.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/DeployUnit.cs
@@ -50,6 +50,7 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
         };
 
         public abstract AsimovTask GetDeployTask(AsimovVersion version, ParameterValues parameterValues, AsimovUser user, string correlationId);
+        public abstract void SetupDeployActions();
 
         public virtual DeployUnitInfo GetUnitInfo(bool refreshUnitStatus)
         {

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/FileCopyDeployUnit.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/FileCopyDeployUnit.cs
@@ -34,5 +34,7 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
             task.AddDeployStep<FileCopyDeployStep>();
             return task;
         }
+
+        public override void SetupDeployActions() { }
     }
 }

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/ICanBeKilled.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/ICanBeKilled.cs
@@ -1,0 +1,9 @@
+﻿using AsimovDeploy.WinAgent.Framework.Common;
+
+namespace AsimovDeploy.WinAgent.Framework.Models.Units
+{
+    public interface ICanBeKilled
+    {
+        AsimovTask GetKillTask();
+    }
+}

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/PowershellDeployUnit.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/PowershellDeployUnit.cs
@@ -35,12 +35,14 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
             return task;
         }
 
+        public override void SetupDeployActions() { }
+
         public override DeployUnitInfo GetUnitInfo(bool refreshUnitStatus)
         {
             var deployUnitInfo = base.GetUnitInfo(refreshUnitStatus);
 
             deployUnitInfo.Status = UnitStatus.NA;
-            deployUnitInfo.Url = Url != null ? Url.Replace("localhost", HostNameUtil.GetFullHostName()) : null;
+            deployUnitInfo.Url = Url?.Replace("localhost", HostNameUtil.GetFullHostName());
 
             return deployUnitInfo;
         }

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/WebSiteDeployUnit.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/WebSiteDeployUnit.cs
@@ -36,20 +36,20 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
     {
         private string siteName;
         private int _lastUnitStatus;
-
-        public WebSiteDeployUnit()
-        {
-            CleanDeploy = true; // default to true
-            Actions.Add(new StartDeployUnitAction {Sort = 10});
-            Actions.Add(new StopDeployUnitAction {Sort = 11});
-
-            Actions.Add(new UnInstallUnitAction {Sort = 20});
-            _lastUnitStatus = (int)UnitStatus.NA;
-        }
-
+        
         public bool CleanDeploy { get; set; }
 
         public AsimovTask GetStopTask() => new StartStopWebApplicationTask(this, true);
+
+        public override void SetupDeployActions()
+        {
+            CleanDeploy = true; // default to true
+            Actions.Add(new StartDeployUnitAction { Sort = 10 });
+            Actions.Add(new StopDeployUnitAction { Sort = 11 });
+
+            Actions.Add(new UnInstallUnitAction { Sort = 20 });
+            _lastUnitStatus = (int)UnitStatus.NA;
+        }
 
         public AsimovTask GetStartTask() => new StartStopWebApplicationTask(this, false);
 
@@ -72,7 +72,9 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
             get { return siteName ?? Name; }
             set { siteName = value; }
         }
+
         public string SiteUrl { get; set; }
+
         public InstallableConfig Installable { get; set; }
 
         public override string UnitType => DeployUnitTypes.WebSite;

--- a/src/AsimovDeploy.WinAgent/Framework/Tasks/KillWindowsServiceTask.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Tasks/KillWindowsServiceTask.cs
@@ -1,0 +1,24 @@
+﻿using System.ServiceProcess;
+using AsimovDeploy.WinAgent.Framework.Common;
+using AsimovDeploy.WinAgent.Framework.Events;
+using AsimovDeploy.WinAgent.Framework.Models.Units;
+using AsimovDeploy.WinAgent.Framework.Tasks.ServiceControl;
+
+namespace AsimovDeploy.WinAgent.Framework.Tasks
+{
+    public class KillWindowsServiceTask : AsimovTask
+    {
+        private readonly WindowsServiceDeployUnit _unit;
+
+        public KillWindowsServiceTask(WindowsServiceDeployUnit unit) => _unit = unit;
+        protected override string InfoString() => "Killing " + _unit.Name;
+
+        protected override void Execute()
+        {
+            using (var controller = new ServiceController(_unit.ServiceName))
+                controller.KillServiceProcess();
+            var unitInfo = _unit.GetUnitInfo(true);
+            new NodeFront().Notify(new UnitStatusChangedEvent(_unit.Name, unitInfo.Status));
+        }
+    }
+}

--- a/src/AsimovDeploy.WinAgent/Framework/Tasks/StartStopWindowsServiceTask.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Tasks/StartStopWindowsServiceTask.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ServiceProcess;
-using System.Threading;
 using AsimovDeploy.WinAgent.Framework.Common;
 using AsimovDeploy.WinAgent.Framework.Events;
 using AsimovDeploy.WinAgent.Framework.Models;
@@ -10,61 +9,57 @@ using log4net;
 
 namespace AsimovDeploy.WinAgent.Framework.Tasks
 {
-	public class StartStopWindowsServiceTask : AsimovTask
-	{
-		private static ILog _log = LogManager.GetLogger(typeof(StartStopWindowsServiceTask));
+    public class StartStopWindowsServiceTask : AsimovTask
+    {
+        private static readonly ILog _log = LogManager.GetLogger(typeof(StartStopWindowsServiceTask));
 
-		private readonly WindowsServiceDeployUnit _unit;
-		private readonly bool _stop;
+        private readonly WindowsServiceDeployUnit _unit;
+        private readonly bool _stop;
         private readonly NodeFront _nodefront = new NodeFront();
 
-		public StartStopWindowsServiceTask(WindowsServiceDeployUnit unit, bool stop)
-		{
-			_unit = unit;
-			_stop = stop;
-		}
+        public StartStopWindowsServiceTask(WindowsServiceDeployUnit unit, bool stop)
+        {
+            _unit = unit;
+            _stop = stop;
+        }
 
-		protected override string InfoString()
-		{
-			return (_stop ? "Stopping " : "Starting ") + _unit.Name;
-		}
+        protected override string InfoString() => (_stop ? "Stopping " : "Starting ") + _unit.Name;
 
-		protected override void Execute()
-		{
-			var intermediateStatus = _stop ? UnitStatus.Stopping : UnitStatus.Starting;
-			var endStatus = _stop ? UnitStatus.Stopped : UnitStatus.Running;
+        protected override void Execute()
+        {
+            var intermediateStatus = _stop ? UnitStatus.Stopping : UnitStatus.Starting;
+            var endStatus = _stop ? UnitStatus.Stopped : UnitStatus.Running;
 
             _nodefront.Notify(new UnitStatusChangedEvent(_unit.Name, intermediateStatus));
 
-			using (var controller = new ServiceController(_unit.ServiceName))
-			{
-				if (_stop) StopService(controller);
-				else StartService(controller);
+            using (var controller = new ServiceController(_unit.ServiceName))
+            {
+                if (_stop) StopService(controller);
+                else StartService(controller);
+            }
 
-			}
+            var unitInfo = _unit.GetUnitInfo(true);
 
-			var unitInfo = _unit.GetUnitInfo(true);
-
-			if (unitInfo.Status != endStatus)
-			{
-				_log.Error(string.Format("Failed to {0} {1}", (_stop ? "stop" : "start"), _unit.Name));
-			}
+            if (unitInfo.Status != endStatus)
+            {
+                _log.Error($"Failed to {(_stop ? "stop" : "start")} {_unit.Name}");
+            }
 
             _nodefront.Notify(new UnitStatusChangedEvent(_unit.Name, unitInfo.Status));
-		}
+        }
 
-		private void StartService(ServiceController controller)
-		{
-			controller.Start();
-			controller.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromMinutes(2));
-		}
+        private void StartService(ServiceController controller)
+        {
+            controller.Start();
+            controller.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromMinutes(2));
+        }
 
-		private static void StopService(ServiceController controller)
-		{
-			if (controller.Status == ServiceControllerStatus.Running)
+        private static void StopService(ServiceController controller)
+        {
+            if (controller.Status == ServiceControllerStatus.Running)
                 controller.StopServiceAndWaitForExit();
-		}
-	}
+        }
+    }
 
 
 }


### PR DESCRIPTION
Added ICanBeKilled to be able to kill windows services which are stuck in "stopping". config needed for the ones that should have this: "CanBeKilled" : "true".

Also moved code from constuctor into new abstract method "SetupDeployActions" in the deploy units, which are called after loading config. This is to be able to check config before presenting available actions