### PR TITLE
Use absolute uri for verify reports if supplied

### DIFF
--- a/src/AsimovDeploy.WinAgent.Tests/Tasks/ChangeLoadBalancerStateTaskSpecs.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/Tasks/ChangeLoadBalancerStateTaskSpecs.cs
@@ -1,5 +1,4 @@
 ﻿using AsimovDeploy.WinAgent.Framework.Common;
-using AsimovDeploy.WinAgent.Framework.Events;
 using AsimovDeploy.WinAgent.Framework.LoadBalancers;
 using AsimovDeploy.WinAgent.Framework.Models;
 using AsimovDeploy.WinAgent.Framework.Tasks;
@@ -86,16 +85,8 @@ namespace AsimovDeploy.WinAgent.Tests.Tasks
 			get { return _config; }
 		}
 	}
-	public class FakeNotifier : INotifier
-	{
-		public bool WasNotified = false;
-		public void Notify(AsimovEvent data)
-		{
-			WasNotified = true;
-		}
-	}
 
-	public class FakeLoadBalancerService : ILoadBalancerService
+    public class FakeLoadBalancerService : ILoadBalancerService
 	{
 		public bool StartState;
 		public int NumberOfSecondsThatActionTakesToComplete = 11;

--- a/src/AsimovDeploy.WinAgent.Tests/Tasks/FakeNotifier.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/Tasks/FakeNotifier.cs
@@ -1,0 +1,18 @@
+﻿using AsimovDeploy.WinAgent.Framework.Common;
+using AsimovDeploy.WinAgent.Framework.Events;
+
+namespace AsimovDeploy.WinAgent.Tests.Tasks
+{
+    public class FakeNotifier : INotifier
+    {
+        public bool WasNotified = false;
+
+        public AsimovEvent LastEvent { get; set; }
+        
+        public void Notify(AsimovEvent data)
+        {
+            LastEvent = data;
+            WasNotified = true;
+        }
+    }
+}

--- a/src/AsimovDeploy.WinAgent.Tests/Tasks/VerifyCommanTaskSpecs.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/Tasks/VerifyCommanTaskSpecs.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AsimovDeploy.WinAgent.Framework.Models;
+using AsimovDeploy.WinAgent.Framework.Models.Units;
+using AsimovDeploy.WinAgent.Framework.Tasks;
+using AsimovDeploy.WinAgent.Web.Commands;
+using NUnit.Framework;
+using Shouldly;
+
+namespace AsimovDeploy.WinAgent.Tests.Tasks
+{
+    [TestFixture]
+    public class VerifyCommanTaskSpecs
+    {
+        private FakeNotifier _fakeNotifier;
+        private TestVerifyCommandTask _verifyTask;
+        private FakeNotifier _notifier;
+        private AsimovConfig _config;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _config = new AsimovConfig();
+            _verifyTask = new TestVerifyCommandTask(
+                _config,
+                new WebSiteDeployUnit(),
+                "zippath",
+                "command",
+                "3A477B55-52BE-45D2-9650-A5E6DD607B24"
+            );
+        }
+
+
+        [Test]
+        public void relative_report_paths_should_be_prepended_with_agent_web_control_url()
+        {
+            _verifyTask.ParseVerifyCommandOutput("##asimov-deploy[report='relative-path' title='my report']");
+            Assert.AreEqual($"{_config.WebControlUrl}temp-reports/relative-path", _verifyTask.Report.url);
+        }
+
+        [Test]
+        public void absolute_report_paths_should_be_passed_on_without_modification()
+        {
+            _verifyTask.ParseVerifyCommandOutput("##asimov-deploy[report='http://test.local/report.html' title='my report']");
+            Assert.AreEqual("http://test.local/report.html", _verifyTask.Report.url);
+        }
+    }
+
+    class TestVerifyCommandTask : VerifyCommandTask
+    {
+        public TestVerifyCommandTask(
+            IAsimovConfig config,
+            WebSiteDeployUnit webSiteDeployUnit, 
+            string zipPath, 
+            string command, 
+            string correlationId) : base(webSiteDeployUnit, zipPath, command, correlationId)
+        {
+            _config = config;
+        }
+
+        protected override IAsimovConfig Config => _config;
+
+        public Report Report => base.report;
+    }
+}

--- a/src/AsimovDeploy.WinAgent/Framework/Common/AsimovTask.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Common/AsimovTask.cs
@@ -64,7 +64,7 @@ namespace AsimovDeploy.WinAgent.Framework.Common
 
         public void RaiseExecuted(Exception exception) => Completed?.Invoke(exception);
 
-        private IAsimovConfig _config;
+        protected IAsimovConfig _config;
         protected virtual IAsimovConfig Config => _config ?? (_config = ObjectFactory.GetInstance<IAsimovConfig>());
 
         protected virtual void AddTask(AsimovTask task)


### PR DESCRIPTION
This change allows us to link verify reports that are stored outside the instance. 