### PR TITLE
Decrease cloud storage poll frequency in winagent updater

### DIFF
--- a/src/AsimovDeploy.WinAgentUpdater/GoogleStorageUpdateInfoCollector.cs
+++ b/src/AsimovDeploy.WinAgentUpdater/GoogleStorageUpdateInfoCollector.cs
@@ -52,7 +52,7 @@ namespace AsimovDeploy.WinAgentUpdater
             var regex = new Regex(@"(?<fileName>AsimovDeploy.WinAgent.ConfigFiles-Version-(\d+).zip)");
             var list = new List<AsimovConfigUpdate>();
 
-            foreach (var bucket in _client.ListObjects(_bucket, _prefix))
+            foreach (var bucket in _client.ListObjects(_bucket, _prefix + "/AsimovDeploy.WinAgent.ConfigFiles-Version"))
             {
                 var match = regex.Match(bucket.Name);
                 if (match.Success)
@@ -74,7 +74,7 @@ namespace AsimovDeploy.WinAgentUpdater
             var pattern = @"v(?<major>\d+)\.(?<minor>\d+)\.(?<build>\d+)";
             var regex = new Regex(pattern);
             var list = new List<AsimovVersion>();
-            foreach (var bucket in _client.ListObjects(_bucket, _prefix))
+            foreach (var bucket in _client.ListObjects(_bucket, _prefix + "/AsimovDeploy.WinAgent-v"))
             {
                 var match = regex.Match(bucket.Name);
                 if (match.Success)

--- a/src/AsimovDeploy.WinAgentUpdater/Updater.cs
+++ b/src/AsimovDeploy.WinAgentUpdater/Updater.cs
@@ -14,7 +14,7 @@ namespace AsimovDeploy.WinAgentUpdater
 
         private static ILog _log = LogManager.GetLogger(typeof(Updater));
         private string _installDir;
-        private const int interval = 4000;
+        private static readonly int interval = (int)TimeSpan.FromMinutes(1).TotalMilliseconds;
 
         private IUpdateInfoCollector _collector;
         


### PR DESCRIPTION
Previous poll frequency for winagentupdater was every 4 seconds
With 50 instances, that amounts to about 2 000 000 requests per day, which makes it a visible cost
This commit reduces the poll frequency to once every minute