### PR TITLE
Prevent error with null packagesource

### DIFF
--- a/src/AsimovDeploy.WinAgent.IntegrationTests/WinAgentSystemTest.cs
+++ b/src/AsimovDeploy.WinAgent.IntegrationTests/WinAgentSystemTest.cs
@@ -96,11 +96,11 @@ namespace AsimovDeploy.WinAgent.IntegrationTests
             Directory.CreateDirectory(TempDir);
             Directory.CreateDirectory(PackagesDir);
 
-            Debug.WriteLine("WorkingDir = " + WorkingDir);
-            Debug.WriteLine("AgentDir = " + AgentDir);
-            Debug.WriteLine("DataDir = " + DataDir);
-            Debug.WriteLine("TempDir = " + TempDir);
-            Debug.WriteLine("PackagesDir = " + PackagesDir);
+            Console.WriteLine("WorkingDir = " + WorkingDir);
+            Console.WriteLine("AgentDir = " + AgentDir);
+            Console.WriteLine("DataDir = " + DataDir);
+            Console.WriteLine("TempDir = " + TempDir);
+            Console.WriteLine("PackagesDir = " + PackagesDir);
         }
 
         public void CopyAgentToCleanRunFolder()
@@ -125,7 +125,7 @@ namespace AsimovDeploy.WinAgent.IntegrationTests
             AgentProcess.StartInfo.RedirectStandardOutput = true;
             AgentProcess.Start();
 
-            RedirectAgentOutputToDebug(AgentProcess.StandardOutput);
+            RedirectAgentOutputToConsole(AgentProcess.StandardOutput);
 
             Thread.Sleep(5000);
 
@@ -157,7 +157,7 @@ namespace AsimovDeploy.WinAgent.IntegrationTests
             }
         }
 
-        private void RedirectAgentOutputToDebug(StreamReader input)
+        private void RedirectAgentOutputToConsole(StreamReader input)
         {
             new Thread(a =>
             {
@@ -168,13 +168,12 @@ namespace AsimovDeploy.WinAgent.IntegrationTests
                     str.Append(buffer[0]);
                     if (buffer[0] == '\n')
                     {
-                        Debug.Write("[AgentOutput]: " + str);
-                        Debug.Flush();
+                        Console.Write("[AgentOutput]: " + str);
                         str.Clear();
                     }
                 };
 
-                Debug.WriteLine("[AgentOutput]: output ended");
+                Console.WriteLine("[AgentOutput]: output ended");
             }).Start();
         }
     }

--- a/src/AsimovDeploy.WinAgent.Tests/AsimovDeploy.WinAgent.Tests.csproj
+++ b/src/AsimovDeploy.WinAgent.Tests/AsimovDeploy.WinAgent.Tests.csproj
@@ -26,6 +26,9 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="ConfigExamples\config.no-packagesource.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="ConfigExamples\config.deploy-parameters.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/AsimovDeploy.WinAgent.Tests/ConfigExamples/config.json
+++ b/src/AsimovDeploy.WinAgent.Tests/ConfigExamples/config.json
@@ -40,6 +40,7 @@
 		"testagent1": { "Environment" : "test1", "LoadBalancerParameters": { "Partition": "testgroup1" } },
 		"testagent2": { "Environment" : "test2" },
 		"testagent3": { "Environment" : "test1, deploy-parameters" },
-		"deploy-parameters": { "Environment" : "deploy-parameters" }
+		"no-packagesource-agent": { "Environment" : "no-packagesource" },
+    "deploy-parameters": { "Environment" : "deploy-parameters" }
 	}	
 }

--- a/src/AsimovDeploy.WinAgent.Tests/ConfigurationSpecs.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/ConfigurationSpecs.cs
@@ -224,12 +224,12 @@ namespace AsimovDeploy.WinAgent.Tests
         {
             var config = ReadConfig("ConfigExamples", "asd");
 
-            config.Units[0].Actions.Count.ShouldBe(6);
+            config.Units[0].Actions.OrderBy(x=>x.Sort).Select(x=>x.Name).ShouldBe(new []{"Rollback", "verify1", "verify2", "Start", "Stop"});
 
-            config.Units[0].Actions[4].ShouldBeTypeOf<VerifyUrlsUnitAction>();
-            config.Units[0].Actions[5].ShouldBeTypeOf<VerifyCommandUnitAction>();
+            config.Units[0].Actions[1].ShouldBeTypeOf<VerifyUrlsUnitAction>();
+            config.Units[0].Actions[2].ShouldBeTypeOf<VerifyCommandUnitAction>();
 
-            var commandAction = (VerifyCommandUnitAction) config.Units[0].Actions[5];
+            var commandAction = (VerifyCommandUnitAction) config.Units[0].Actions[2];
             commandAction.ZipPath.ShouldBe("SiteVerify.zip");
             commandAction.Command.ShouldBe("phantomjs.exe");
         }

--- a/src/AsimovDeploy.WinAgent.Tests/ConfigurationSpecs.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/ConfigurationSpecs.cs
@@ -251,6 +251,19 @@ namespace AsimovDeploy.WinAgent.Tests
         }
 
         [Test]
+        public void unit_without_package_source_should_have_null_package_source()
+        {
+            var config = ReadConfig("ConfigExamples", "no-packagesource-agent");
+
+            config.Units.Count.ShouldBe(2);
+
+            var testService = (WindowsServiceDeployUnit)config.Units[1];
+            var packageSource = config.GetPackageSourceFor(testService);
+            packageSource.ShouldBeTypeOf<NullPackageSource>();
+
+        }
+
+        [Test]
         public void can_get_agent_groups()
         {
             var config = ReadConfig("ConfigExamples", "testagent3");

--- a/src/AsimovDeploy.WinAgent/Framework/Configuration/AsimovConfigConverter.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Configuration/AsimovConfigConverter.cs
@@ -71,8 +71,6 @@ namespace AsimovDeploy.WinAgent.Framework.Configuration
                 var env = new DeployEnvironment();
                 PopulateFromFile(envConfigFile, serializer, env);
                 config.Environments.Add(env);
-
-                config.Units?.ForEach(t => t.SetupDeployActions());
             }
 
             return config;

--- a/src/AsimovDeploy.WinAgent/Framework/Configuration/ConfigurationReader.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Configuration/ConfigurationReader.cs
@@ -48,6 +48,7 @@ namespace AsimovDeploy.WinAgent.Framework.Configuration
                         AddScriptsDir(configDir, deployUnit);
 
                         CreateDirectoryIfNotExists(deployUnit.DataDirectory);
+                        deployUnit.SetupDeployActions();
                         deployUnit.Refresh();
                     }
 

--- a/src/AsimovDeploy.WinAgent/Framework/Models/AsimovConfig.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/AsimovConfig.cs
@@ -179,6 +179,10 @@ namespace AsimovDeploy.WinAgent.Framework.Models
 
         public PackageSource GetPackageSourceFor(DeployUnit deployUnit)
         {
+            if (deployUnit.PackageInfo?.Source == null)
+            {
+                return new NullPackageSource();
+            }
             var matchingPackageSources = PackageSources.Where(x => x.Name == deployUnit.PackageInfo.Source).ToList();
             if (matchingPackageSources.Count == 0)
             {

--- a/src/AsimovDeploy.WinAgent/Framework/Models/UnitActions/UnitActionList.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/UnitActions/UnitActionList.cs
@@ -29,5 +29,18 @@ namespace AsimovDeploy.WinAgent.Framework.Models.UnitActions
     public class UnitActionList : List<UnitAction>
     {
         public UnitAction this[string name] => this.SingleOrDefault(x => x.Name == name);
+
+
+        /// <summary>
+        /// Adds an UnitAction if there are no actions of the same type in the collection. Does nothing otherwise.
+        /// </summary>
+        /// <returns>True if the action was added</returns>
+        public bool AddIfFirstOfType<T>(T action) where T : UnitAction
+        {
+            if (this.OfType<T>().Any())
+                return false;
+            Add(action);
+            return true;
+        }
     }
 }

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/WindowsServiceDeployUnit.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/WindowsServiceDeployUnit.cs
@@ -42,15 +42,14 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
 
         public override void SetupDeployActions()
         {
-            if (!Actions.OfType<StartDeployUnitAction>().Any())
-                Actions.Add(new StartDeployUnitAction { Sort = 10 });
-            if (!Actions.OfType<StopDeployUnitAction>().Any())
-                Actions.Add(new StopDeployUnitAction { Sort = 11 });
-            if (CanBeKilled && !Actions.OfType<KillDeployUnitAction>().Any())
-                Actions.Add(new KillDeployUnitAction { Sort = 12 });
+            Actions.AddIfFirstOfType(new StartDeployUnitAction { Sort = 10 });
+            Actions.AddIfFirstOfType(new StopDeployUnitAction { Sort = 11 });
+            
+            if (CanBeKilled)
+                Actions.AddIfFirstOfType(new KillDeployUnitAction { Sort = 12 });
 
-            if (Installable?.IsUninstallable == true && !Actions.OfType<UnInstallUnitAction>().Any())
-                Actions.Add(new UnInstallUnitAction() { Sort = 20 });
+            if (Installable?.IsUninstallable == true)
+                Actions.AddIfFirstOfType(new UnInstallUnitAction() { Sort = 20 });
 
             _lastUnitStatus = (int)UnitStatus.NA;
         }

--- a/src/AsimovDeploy.WinAgent/Web/Modules/UnitActionModule.cs
+++ b/src/AsimovDeploy.WinAgent/Web/Modules/UnitActionModule.cs
@@ -1,4 +1,5 @@
-﻿using AsimovDeploy.WinAgent.Framework.Common;
+﻿using System.Linq;
+using AsimovDeploy.WinAgent.Framework.Common;
 using AsimovDeploy.WinAgent.Framework.Models;
 using AsimovDeploy.WinAgent.Web.Commands;
 using Nancy;
@@ -6,24 +7,33 @@ using Nancy.ModelBinding;
 
 namespace AsimovDeploy.WinAgent.Web.Modules
 {
-	public class UnitActionModule : NancyModule
-	{
-		public UnitActionModule(ITaskExecutor taskExecutor, IAsimovConfig config)
-		{
-			Post["/action"] = _ =>
-			{
-				var command = this.Bind<UnitActionCommand>();
-				var deployUnit = config.GetUnitByName(command.unitName);
-				var action = deployUnit.Actions[command.actionName];
-			    var asimovUser = new AsimovUser() {UserId = command.userId, UserName = command.userName};
+    public class UnitActionModule : NancyModule
+    {
+        public UnitActionModule(ITaskExecutor taskExecutor, IAsimovConfig config)
+        {
+            Post["/action"] = _ =>
+            {
+                var command = this.Bind<UnitActionCommand>();
+                var deployUnit = config.GetUnitByName(command.unitName);
+                var action = deployUnit.Actions[command.actionName];
+                if (action == null)
+                {
+                    return Response.AsJson(new
+                    {
+                        OK = false, 
+                        Message=$"No action found with name {command.actionName}.", 
+                        AvailableActions=deployUnit.Actions.Select(x=>x.Name)
+                    }, HttpStatusCode.BadRequest);
+                }
+                var asimovUser = new AsimovUser() { UserId = command.userId, UserName = command.userName };
 
-				var task = action.GetTask(deployUnit,asimovUser, command.correlationId);
+                var task = action.GetTask(deployUnit, asimovUser, command.correlationId);
 
-                if(task != null)
-				    taskExecutor.AddTask(task);
+                if (task != null)
+                    taskExecutor.AddTask(task);
 
-				return Response.AsJson(new { OK = true });
-			};
-		}
-	}
+                return Response.AsJson(new { OK = true });
+            };
+        }
+    }
 }


### PR DESCRIPTION
Previously the server would return an error when getting versions from a unit without a package source. This PR changes that so that we instead get an empty list of versions. 

Also included are changes to fix integration tests and make them easier to debug.