### PR TITLE
Update dependencies and set OutputType to Console

### DIFF
--- a/src/AsimovDeploy.WinAgent.IntegrationTests/AsimovDeploy.WinAgent.IntegrationTests.csproj
+++ b/src/AsimovDeploy.WinAgent.IntegrationTests/AsimovDeploy.WinAgent.IntegrationTests.csproj
@@ -5,13 +5,13 @@
     <AssemblyName>AsimovDeploy.WinAgent.IntegrationTests</AssemblyName>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="Shouldly" Version="1.1.1.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
 
   </ItemGroup>
   <ItemGroup>

--- a/src/AsimovDeploy.WinAgent.Tests/AsimovDeploy.WinAgent.Tests.csproj
+++ b/src/AsimovDeploy.WinAgent.Tests/AsimovDeploy.WinAgent.Tests.csproj
@@ -2,14 +2,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="Shouldly" Version="1.1.1.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="Shouldly" Version="3.0.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="LoadbalancerConfig\config.json">

--- a/src/AsimovDeploy.WinAgent.Tests/ConfigurationSpecs.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/ConfigurationSpecs.cs
@@ -116,14 +116,14 @@ namespace AsimovDeploy.WinAgent.Tests
             var unit = config.GetUnitByName("UnitWithParameters");
 
             unit.HasDeployParameters.ShouldBe(true);
-            unit.DeployParameters[0].ShouldBeTypeOf<TextActionParameter>();
+            unit.DeployParameters[0].ShouldBeOfType<TextActionParameter>();
             ((TextActionParameter) unit.DeployParameters[0]).Default.ShouldBe("Deploy-Everything");
 
-            unit.DeployParameters[1].ShouldBeTypeOf<PasswordActionParameter>();
+            unit.DeployParameters[1].ShouldBeOfType<PasswordActionParameter>();
             ((PasswordActionParameter)unit.DeployParameters[1]).Password.ShouldBe("Password!");
             ((PasswordActionParameter)unit.DeployParameters[1]).Default.ShouldBe(null);
 
-            unit.DeployParameters[2].ShouldBeTypeOf<PasswordActionParameter>();
+            unit.DeployParameters[2].ShouldBeOfType<PasswordActionParameter>();
             ((PasswordActionParameter)unit.DeployParameters[2]).Password.ShouldBe(null);
             ((PasswordActionParameter)unit.DeployParameters[2]).Default.ShouldBe("DefaultPassword");
         }
@@ -226,8 +226,8 @@ namespace AsimovDeploy.WinAgent.Tests
 
             config.Units[0].Actions.OrderBy(x=>x.Sort).Select(x=>x.Name).ShouldBe(new []{"Rollback", "verify1", "verify2", "Start", "Stop"});
 
-            config.Units[0].Actions[1].ShouldBeTypeOf<VerifyUrlsUnitAction>();
-            config.Units[0].Actions[2].ShouldBeTypeOf<VerifyCommandUnitAction>();
+            config.Units[0].Actions[1].ShouldBeOfType<VerifyUrlsUnitAction>();
+            config.Units[0].Actions[2].ShouldBeOfType<VerifyCommandUnitAction>();
 
             var commandAction = (VerifyCommandUnitAction) config.Units[0].Actions[2];
             commandAction.ZipPath.ShouldBe("SiteVerify.zip");
@@ -259,7 +259,7 @@ namespace AsimovDeploy.WinAgent.Tests
 
             var testService = (WindowsServiceDeployUnit)config.Units[1];
             var packageSource = config.GetPackageSourceFor(testService);
-            packageSource.ShouldBeTypeOf<NullPackageSource>();
+            packageSource.ShouldBeOfType<NullPackageSource>();
 
         }
 

--- a/src/AsimovDeploy.WinAgent/AsimovDeploy.WinAgent.csproj
+++ b/src/AsimovDeploy.WinAgent/AsimovDeploy.WinAgent.csproj
@@ -1,30 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <ApplicationIcon />
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <StartupObject>AsimovDeploy.WinAgent.Program</StartupObject>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.19" />
+    <PackageReference Include="AWSSDK.Core" Version="3.3.31.5" />
     <PackageReference Include="AWSSDK.S3" Version="3.3.15" />
-    <PackageReference Include="DotNetZip" Version="1.9.1.8" />
-    <PackageReference Include="EasyHttp" Version="1.6.58.0" />
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="2.1.0" />
+    <PackageReference Include="DotNetZip" Version="1.13.0" />
+    <PackageReference Include="EasyHttp" Version="1.7.0" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="2.2.1" />
     <PackageReference Include="IIS.Microsoft.Web.Administration" Version="8.5.9600.17042" />
     <PackageReference Include="JsonFx" Version="2.0.1209.2802" />
-    <PackageReference Include="log4net" Version="2.0.0" />
+    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Nancy" Version="0.11.0" />
     <PackageReference Include="Nancy.Bootstrappers.StructureMap" Version="0.11.0" />
     <PackageReference Include="Nancy.Hosting.Self" Version="0.11.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="structuremap" Version="2.6.3" />
-    <PackageReference Include="System.Interactive.Async" Version="3.1.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.1" />
-    <PackageReference Include="Topshelf" Version="2.3.0.0" />
-    <PackageReference Include="Topshelf.Log4Net" Version="2.3.0.0" />
+    <PackageReference Include="System.Interactive.Async" Version="3.2.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Topshelf" Version="4.2.0" />
+    <PackageReference Include="Topshelf.Log4Net" Version="4.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\SharedAssemblyInfo.cs">

--- a/src/AsimovDeploy.WinAgent/Program.cs
+++ b/src/AsimovDeploy.WinAgent/Program.cs
@@ -17,16 +17,11 @@ namespace AsimovDeploy.WinAgent
             
             var host = HostFactory.New(x =>
             {
-                x.BeforeStartingServices(s => _log.DebugFormat("Starting {0}...", ServiceName));
-                x.AfterStoppingServices(s => _log.DebugFormat("Stopping {0}...", ServiceName));
-                
+                x.SetServiceName(ServiceName);
+
                 x.Service<IAsimovDeployService>(s =>
                 {
-                    s.SetServiceName(ServiceName);
-                    s.ConstructUsing(name =>
-                    {
-                        return new AsimovDeployService();
-                    });
+                    s.ConstructUsing(name => new AsimovDeployService());
 
                     s.WhenStarted(tc => tc.Start());
                     s.WhenStopped(tc => tc.Stop());

--- a/src/AsimovDeploy.WinAgentUpdater/AsimovDeploy.WinAgentUpdater.csproj
+++ b/src/AsimovDeploy.WinAgentUpdater/AsimovDeploy.WinAgentUpdater.csproj
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net452</TargetFramework>
     <ApplicationIcon />
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
     <StartupObject>AsimovDeploy.WinAgentUpdater.Program</StartupObject>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.9.1.8" />
-    <PackageReference Include="log4net" Version="2.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-    <PackageReference Include="Topshelf" Version="2.3.0.0" />
-    <PackageReference Include="Topshelf.Log4Net" Version="2.3.0.0" />
-    <PackageReference Include="Google.Cloud.Storage.V1" Version="2.1.0" />
+    <PackageReference Include="DotNetZip" Version="1.13.0" />
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Topshelf" Version="4.2.0" />
+    <PackageReference Include="Topshelf.Log4Net" Version="4.2.0" />
+    <PackageReference Include="Google.Cloud.Storage.V1" Version="2.2.1" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/src/AsimovDeploy.WinAgentUpdater/Program.cs
+++ b/src/AsimovDeploy.WinAgentUpdater/Program.cs
@@ -15,12 +15,10 @@ namespace AsimovDeploy.WinAgentUpdater
 
             var host = HostFactory.New(x =>
             {
-                x.BeforeStartingServices(s => _log.InfoFormat("Starting {0}...", ServiceName));
-                x.AfterStoppingServices(s => _log.InfoFormat("Stopping {0}...", ServiceName));
+                x.SetServiceName(ServiceName);
 
                 x.Service<Updater>(s =>
                 {
-                    s.SetServiceName(ServiceName);
                     s.ConstructUsing(name => new Updater());
 
                     s.WhenStarted(tc => tc.Start());


### PR DESCRIPTION
This commit contains two changes:
1) All dependencies except StructureMap and Nancy are updated to latest version
2) Output type has changed from WinExe (Windows app) to Exe (Console) to enable running in command line

I haven't tested these changes yet, probably best to hold until we have tested internally