### PR TITLE
Set a default timeout for a service to stop when deploying

### DIFF
--- a/src/AsimovDeploy.WinAgent.IntegrationTests/WinAgentSystemTest.cs
+++ b/src/AsimovDeploy.WinAgent.IntegrationTests/WinAgentSystemTest.cs
@@ -105,7 +105,7 @@ namespace AsimovDeploy.WinAgent.IntegrationTests
 
         public void CopyAgentToCleanRunFolder()
         {
-            DirectoryUtil.CopyDirectory(Path.Combine(TestContext.CurrentContext.TestDirectory,@"..\..\..\..\AsimovDeploy.WinAgent\bin\Debug\net45"), AgentDir);
+            DirectoryUtil.CopyDirectory(Path.Combine(TestContext.CurrentContext.TestDirectory,@"..\..\..\..\AsimovDeploy.WinAgent\bin\Debug\net452"), AgentDir);
         }
 
         public void GivenRunningAgent()

--- a/src/AsimovDeploy.WinAgent/Framework/Deployment/Steps/UpdateWindowsService.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Deployment/Steps/UpdateWindowsService.cs
@@ -27,6 +27,7 @@ namespace AsimovDeploy.WinAgent.Framework.Deployment.Steps
     public class UpdateWindowsService : IDeployStep
     {
         private IAsimovConfig _config;
+        private static readonly TimeSpan DefaultStopTimeout = TimeSpan.FromMinutes(2);
 
         public UpdateWindowsService(IAsimovConfig config)
         {
@@ -67,7 +68,7 @@ namespace AsimovDeploy.WinAgent.Framework.Deployment.Steps
             else
             {
                 if (controller.Status == ServiceControllerStatus.Running)
-                    controller.StopServiceAndWaitForExit();
+                    controller.StopServiceAndWaitForExit(DefaultStopTimeout);
             }
         }
 

--- a/src/AsimovDeploy.WinAgent/Framework/Tasks/StartStopWindowsServiceTask.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Tasks/StartStopWindowsServiceTask.cs
@@ -16,6 +16,7 @@ namespace AsimovDeploy.WinAgent.Framework.Tasks
         private readonly WindowsServiceDeployUnit _unit;
         private readonly bool _stop;
         private readonly NodeFront _nodefront = new NodeFront();
+        private static readonly TimeSpan DefaultStartStopTimeout = TimeSpan.FromMinutes(2);
 
         public StartStopWindowsServiceTask(WindowsServiceDeployUnit unit, bool stop)
         {
@@ -51,13 +52,13 @@ namespace AsimovDeploy.WinAgent.Framework.Tasks
         private void StartService(ServiceController controller)
         {
             controller.Start();
-            controller.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromMinutes(2));
+            controller.WaitForStatus(ServiceControllerStatus.Running, DefaultStartStopTimeout);
         }
 
         private static void StopService(ServiceController controller)
         {
             if (controller.Status == ServiceControllerStatus.Running)
-                controller.StopServiceAndWaitForExit();
+                controller.StopServiceAndWaitForExit(DefaultStartStopTimeout);
         }
     }
 


### PR DESCRIPTION
If we don't do this, asimov can hang indefinately waiting for services
to stop. It's better to cancel the deploy in this case.