### PR TITLE
Increase max task queue limit

### DIFF
--- a/src/AsimovDeploy.WinAgent.Tests/Framework/TaskExecutorSpecs.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/Framework/TaskExecutorSpecs.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AsimovDeploy.WinAgent.Framework.Common;
+using NUnit.Framework;
+using Shouldly;
+
+namespace AsimovDeploy.WinAgent.Tests.Framework
+{
+    [TestFixture]
+    public class TaskExecutorSpecs
+    {
+        [Test]
+        public async Task executes_one_task()
+        {
+            TaskExecutor e = new TaskExecutor();
+            e.Start();
+
+            var testTask = new TestTask();
+            await e.AddTask(testTask);
+            
+            testTask.Executed.ShouldBe(true);
+        }
+
+        [Test]
+        public async Task blocks_when_max_concurrent_tasks_is_reached()
+        {
+            TaskExecutor e = new TaskExecutor();
+            
+            for (int i = 0; i < TaskExecutor.MaxConcurrentTasks; i++)
+            {
+                e.AddTask(new TestTask());
+            }
+
+            var extraTask = Task.Run(() =>
+            {
+                var taskThatWontBeAddedWhileTaskQueueIsFull = new TestTask();
+                e.AddTask(taskThatWontBeAddedWhileTaskQueueIsFull);
+            });
+
+            extraTask.Wait(TimeSpan.FromMilliseconds(500));
+            extraTask.IsCompleted.ShouldBe(false);
+            
+            //Start processing task queue
+            e.Start();
+            
+            extraTask.Wait(TimeSpan.FromMilliseconds(500));
+            extraTask.IsCompleted.ShouldBe(true);
+
+
+        }
+    }
+
+    public class TestTask    : AsimovTask
+    {
+        public bool Executed;
+        protected override void Execute()
+        {
+            Executed = true;
+        }
+    }
+}

--- a/src/AsimovDeploy.WinAgent/Framework/Common/TaskExecutor.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Common/TaskExecutor.cs
@@ -23,9 +23,10 @@ namespace AsimovDeploy.WinAgent.Framework.Common
 {
     public class TaskExecutor : ITaskExecutor, IStartable
     {
+        public const int MaxConcurrentTasks = 1000;
         private static ILog _log = LogManager.GetLogger(typeof (TaskExecutor));
 
-        private BlockingCollection<AsimovTask> _tasks = new BlockingCollection<AsimovTask>(100);
+        private BlockingCollection<AsimovTask> _tasks = new BlockingCollection<AsimovTask>(MaxConcurrentTasks);
 
         private Task _workerTask;
 


### PR DESCRIPTION
We have over 100 services, which means that we won't see how many tasks that are queued. This commit increases the limit so that all our units fit in the queue