### PR TITLE
Add ability to skip verify and waiting for service start during deploys

### DIFF
--- a/src/AsimovDeploy.WinAgent.Tests/DeployUnit/WebSiteDeployUnitTests.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/DeployUnit/WebSiteDeployUnitTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AsimovDeploy.WinAgent.Framework.Deployment.Steps;
+using AsimovDeploy.WinAgent.Framework.Models;
+using AsimovDeploy.WinAgent.Framework.Models.UnitActions;
+using AsimovDeploy.WinAgent.Framework.Models.Units;
+using AsimovDeploy.WinAgent.Framework.Tasks;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using StructureMap;
+
+namespace AsimovDeploy.WinAgent.Tests.DeployUnit
+{
+    [TestFixture]
+    public class WebSiteDeployUnitTests
+    {
+
+        private static DeployTask DeployTask(ParameterValues parameterValues, WebSiteDeployUnit webSiteDeployUnit)
+        {
+            var task = (DeployTask) webSiteDeployUnit.GetDeployTask(new AsimovVersion(), parameterValues,
+                new AsimovUser(), "1");
+            return task;
+        }
+
+        private static WebSiteDeployUnit UnitWithVerify()
+        {
+            ObjectFactory.Initialize(o => { o.For<IAsimovConfig>().Use(new AsimovConfig()); });
+            var unit = new WebSiteDeployUnit();
+
+            unit.Actions.Add(new VerifyCommandUnitAction());
+            return unit;
+        }
+        [Test]
+        public void auto_runs_verify_test()
+        {
+            var deployUnit = UnitWithVerify();
+
+            var task = DeployTask(new ParameterValues(new Dictionary<string, dynamic>()), deployUnit);
+
+            var steps = task.Select(x=>x()).ToArray();
+            Assert.IsInstanceOf<ExecuteUnitAction>(steps.Last());
+
+            var action = (ExecuteUnitAction) steps.Last();
+            Assert.IsInstanceOf<VerifyCommandUnitAction>(action.Action);
+        }
+
+        [Test]
+        public void skips_verify_test_when_skip_verify_is_set()
+        {
+            var deployUnit = UnitWithVerify();
+
+            var task = DeployTask(new ParameterValues(new Dictionary<string, dynamic> {{"SkipVerify", true}}), deployUnit);
+
+            var steps = task.Select(x=>x()).ToArray();
+            Assert.IsNotInstanceOf<ExecuteUnitAction>(steps.Last());
+
+        }
+
+        
+    }
+}

--- a/src/AsimovDeploy.WinAgent.Tests/Framework/TaskExecutorSpecs.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/Framework/TaskExecutorSpecs.cs
@@ -25,7 +25,7 @@ namespace AsimovDeploy.WinAgent.Tests.Framework
         }
 
         [Test]
-        public async Task blocks_when_max_concurrent_tasks_is_reached()
+        public void blocks_when_max_concurrent_tasks_is_reached()
         {
             TaskExecutor e = new TaskExecutor();
             

--- a/src/AsimovDeploy.WinAgent.Tests/Tasks/VerifyCommanTaskSpecs.cs
+++ b/src/AsimovDeploy.WinAgent.Tests/Tasks/VerifyCommanTaskSpecs.cs
@@ -13,7 +13,7 @@ using Shouldly;
 namespace AsimovDeploy.WinAgent.Tests.Tasks
 {
     [TestFixture]
-    public class VerifyCommanTaskSpecs
+    public class VerifyCommandTaskSpecs
     {
         private FakeNotifier _fakeNotifier;
         private TestVerifyCommandTask _verifyTask;

--- a/src/AsimovDeploy.WinAgent/Framework/Deployment/Steps/ExecuteUnitAction.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Deployment/Steps/ExecuteUnitAction.cs
@@ -5,18 +5,18 @@ namespace AsimovDeploy.WinAgent.Framework.Deployment.Steps
 {
     public class ExecuteUnitAction : IDeployStep
     {
-        private readonly UnitAction action;
-        private readonly AsimovUser user;
+        public UnitAction Action { get; }
+        public AsimovUser User { get; }
 
         public ExecuteUnitAction(UnitAction action, AsimovUser user)
         {
-            this.action = action;
-            this.user = user;
+            Action = action;
+            User = user;
         }
 
         public void Execute(DeployContext context)
         {
-            action.GetTask(context.DeployUnit, user, context.CorrelationId).ExecuteTask();
+            Action.GetTask(context.DeployUnit, User, context.CorrelationId).ExecuteTask();
         }
     }
 }

--- a/src/AsimovDeploy.WinAgent/Framework/Deployment/Steps/UpdateWindowsService.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Deployment/Steps/UpdateWindowsService.cs
@@ -51,7 +51,8 @@ namespace AsimovDeploy.WinAgent.Framework.Deployment.Steps
                 context.Log.InfoFormat("Starting service {0}", deployUnit.ServiceName);
                 controller.Start();
 
-                controller.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromMinutes(1));
+                if(!context.ParameterValues.HasValue("SkipWaitForServiceStart",true))
+                    controller.WaitForStatus(ServiceControllerStatus.Running, TimeSpan.FromMinutes(1));
             }
         }
 

--- a/src/AsimovDeploy.WinAgent/Framework/Models/ParameterValues.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/ParameterValues.cs
@@ -28,15 +28,20 @@ namespace AsimovDeploy.WinAgent.Framework.Models
 
         public ParameterValues(IDictionary<string, dynamic> parameters)
         {
-            _parameters = parameters;
+            _parameters = parameters ?? new Dictionary<string, dynamic>();
         }
 
         public dynamic GetValue(string parameterName)
         {
-            if (_parameters == null)
-                return null;
-
             return _parameters[parameterName];
+        }
+
+        public bool HasValue(string parameterName, dynamic expected)
+        {
+            if (!_parameters.TryGetValue(parameterName, out dynamic actual))
+                return false;
+            return actual == expected;
+
         }
 
         public IDictionary<string, dynamic> GetInternalDictionary()

--- a/src/AsimovDeploy.WinAgent/Framework/Models/Units/WebSiteDeployUnit.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Models/Units/WebSiteDeployUnit.cs
@@ -91,8 +91,14 @@ namespace AsimovDeploy.WinAgent.Framework.Models.Units
                 task.AddDeployStep(new InstallWebSite(this));
             else
                 task.AddDeployStep<UpdateWebSite>();
-            foreach (var action in Actions.OfType<VerifyCommandUnitAction>())
-                task.AddDeployStep(new ExecuteUnitAction(action, user));
+
+            //TODO: This should ideally be moved up so that is is applied to all deploy units
+            if (!parameterValues.HasValue("SkipVerify",true))
+            {
+                foreach (var action in Actions.OfType<VerifyCommandUnitAction>())
+                    task.AddDeployStep(new ExecuteUnitAction(action, user));
+            }
+            
             return task;
         }
 

--- a/src/AsimovDeploy.WinAgent/Framework/Tasks/DeployTask.cs
+++ b/src/AsimovDeploy.WinAgent/Framework/Tasks/DeployTask.cs
@@ -15,6 +15,7 @@
 ******************************************************************************/
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -30,7 +31,7 @@ using log4net.Repository.Hierarchy;
 
 namespace AsimovDeploy.WinAgent.Framework.Tasks
 {
-    public class DeployTask : AsimovTask
+    public class DeployTask : AsimovTask, IEnumerable<Func<IDeployStep>>
     {
         private readonly DeployUnit _deployUnit;
         private readonly AsimovVersion _version;
@@ -51,6 +52,7 @@ namespace AsimovDeploy.WinAgent.Framework.Tasks
             AddDeployStep<CleanTempFolder>();
             AddDeployStep<CopyPackageToTempFolder>();
         }
+
 
         public void AddDeployStep<T>() where T : IDeployStep
         {
@@ -174,6 +176,19 @@ namespace AsimovDeploy.WinAgent.Framework.Tasks
 
             logger.AddAppender(fileAppender);
             return logger;
+        }
+
+        public IEnumerator<Func<IDeployStep>> GetEnumerator()
+        {
+            foreach (var step in _steps)
+            {
+                yield return step;
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }


### PR DESCRIPTION
Running verify steps and waiting for services to start before continuing slows down automatic deployments. This PR enables us to opt out of these steps.